### PR TITLE
Add conversion for VectorOfVariables -> VectorAffineFunction{T}

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,3 +1,10 @@
+# Define conversion VectorOfVariable -> VectorAffineFunction{T}
+function MOI.VectorAffineFunction{T}(f::MOI.VectorOfVariables) where T
+    n = length(f.variables)
+    MOI.VectorAffineFunction(collect(1:n), f.variables, ones(T, n), zeros(T, n))
+end
+
+# Define getindex for Vector functions
 function Base.getindex(f::MOI.VectorAffineFunction, i::Integer)
     I = find(oi -> oi == i, f.outputindex)
     MOI.ScalarAffineFunction(f.variables[I], f.coefficients[I], f.constant[i])

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -3,6 +3,20 @@
     x = MOI.VariableReference(1)
     y = MOI.VariableReference(2)
     z = MOI.VariableReference(3)
+    @testset "Conversion VectorOfVariables -> VectorAffineFunction" begin
+        f = MOI.VectorAffineFunction{Int}(MOI.VectorOfVariables([z, x, y]))
+        @test f isa MOI.VectorAffineFunction{Int}
+        @test f.outputindex == collect(1:3)
+        @test f.variables == [z, x, y]
+        @test all(f.coefficients .== 1)
+        @test all(iszero.(f.constant))
+        f = MOI.VectorAffineFunction{Float64}(MOI.VectorOfVariables([x, w]))
+        @test f isa MOI.VectorAffineFunction{Float64}
+        @test f.outputindex == collect(1:2)
+        @test f.variables == [x, w]
+        @test all(f.coefficients .== 1)
+        @test all(iszero.(f.constant))
+    end
     @testset "getindex on VectorAffineFunction" begin
         f = MOI.VectorAffineFunction([2, 1, 3, 2, 2, 1, 3, 1, 2],
                                      [x, y, z, z, y, z, x, x, y],


### PR DESCRIPTION
It will be useful in tests (e.g. SOCRotated1a, SDP0, SDP1) but also in solver wrappers (e.g. [SOI set bridges](https://github.com/JuliaOpt/SemidefiniteOptInterface.jl/blob/4a9616288a68cfbf32bad62e66417f88038c11ab/src/setbridges.jl#L34)).