### PR TITLE
WIP: parser for compact format for instance specification

### DIFF
--- a/src/MathOptInterfaceUtilities.jl
+++ b/src/MathOptInterfaceUtilities.jl
@@ -18,5 +18,6 @@ include("functions.jl")
 include("sets.jl")
 
 include("instance.jl")
+include("parser.jl")
 
 end # module

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,0 +1,246 @@
+using Base.Meta: isexpr
+
+
+"""
+A parser for a simple human-readable of an MOI instance.
+This should be thought of as a compact way to write small instances
+for tests, and not an exchange format.
+
+variables: x, y, z
+minobjective: 2x + 3y
+con1: x + y <= 1
+con2: [x,y] in Set
+
+special labels: variables, minobjective, maxobjective
+everything else denotes a constraint with a name
+all constraints must be named
+"x - y" does NOT currently parse, needs to be written as "x + -1.0*y"
+"x^2" does NOT currently parse, needs to be written as "x*x"
+"""
+
+struct ParsedScalarAffineFunction
+    variables::Vector{Symbol}
+    coefficients::Vector{Float64}
+    constant::Float64
+end
+
+struct ParsedVectorAffineFunction
+    outputindex::Vector{Int}
+    variables::Vector{Symbol}
+    coefficients::Vector{Float64}
+    constant::Vector{Float64}
+end
+
+struct ParsedScalarQuadraticFunction
+    affine_variables::Vector{Symbol}
+    affine_coefficients::Vector{Float64}
+    quadratic_rowvariables::Vector{Symbol}
+    quadratic_colvariables::Vector{Symbol}
+    quadratic_coefficients::Vector{Float64}
+    constant::Float64
+end
+
+struct ParsedVectorQuadraticFunction
+    affine_outputindex::Vector{Int}
+    affine_variables::Vector{Symbol}
+    affine_coefficients::Vector{Float64}
+    quadratic_outputindex::Vector{Int}
+    quadratic_rowvariables::Vector{Symbol}
+    quadratic_colvariables::Vector{Symbol}
+    quadratic_coefficients::Vector{Float64}
+    constant::Vector{Float64}
+end
+
+struct ParsedSingleVariable
+    variable::Symbol
+end
+
+struct ParsedVectorOfVariables
+    variables::Vector{Symbol}
+end
+
+# Not written with any considerations for performance
+function parsefunction(ex)
+    if isa(ex, Symbol)
+        return ParsedSingleVariable(ex)
+    elseif isexpr(ex, :vect)
+        if all(s -> isa(s, Symbol), ex.args)
+            return ParsedVectorOfVariables(copy(ex.args))
+        else
+            singlefunctions = parsefunction.(ex.args)
+            affine_outputindex = Int[]
+            affine_variables = Symbol[]
+            affine_coefficients = Float64[]
+            quadratic_outputindex = Int[]
+            quadratic_rowvariables = Symbol[]
+            quadratic_colvariables = Symbol[]
+            quadratic_coefficients = Float64[]
+            constant = Float64[]
+            for (outindex,f) in enumerate(singlefunctions)
+                if isa(f, ParsedSingleVariable)
+                    push!(affine_outputindex, outindex)
+                    push!(affine_variables, f.variable)
+                    push!(affine_coefficients, 1.0)
+                    push!(constant, 0.0)
+                elseif isa(f, ParsedScalarAffineFunction)
+                    append!(affine_outputindex, fill(outindex,length(f.variables)))
+                    append!(affine_variables, f.variables)
+                    append!(affine_coefficients, f.coefficients)
+                    push!(constant, f.constant)
+                else
+                    @assert isa(f, ParsedScalarQuadraticFunction)
+                    append!(affine_outputindex, fill(outindex,length(f.affine_variables)))
+                    append!(affine_variables, f.affine_variables)
+                    append!(affine_coefficients, f.affine_coefficients)
+                    append!(quadratic_outputindex, fill(outindex,length(f.quadratic_rowvariables)))
+                    append!(quadratic_rowvariables, f.quadratic_rowvariables)
+                    append!(quadratic_colvariables, f.quadratic_colvariables)
+                    append!(quadratic_coefficients, f.quadratic_coefficients)
+                    push!(constant, f.constant)
+                end
+            end
+            if length(quadratic_outputindex) == 0
+                return ParsedVectorAffineFunction(affine_outputindex, affine_variables, affine_coefficients, constant)
+            else
+                return ParsedVectorQuadraticFunction(affine_outputindex, affine_variables, affine_coefficients, quadratic_outputindex, quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients, constant)
+            end
+        end
+    else
+        # only accept Expr(:call, :+, ...), no recursive expressions
+        # TODO: generalize. x - y + z would be useful
+        if isexpr(ex, :call) && ex.args[1] == :*
+            # handle 2x as 2x + 0
+            ex = Expr(:call,:+,ex,0)
+        end
+        @assert isexpr(ex, :call) && ex.args[1] == :+
+        affine_variables = Symbol[]
+        affine_coefficients = Float64[]
+        quadratic_rowvariables = Symbol[]
+        quadratic_colvariables = Symbol[]
+        quadratic_coefficients = Float64[]
+        constant = 0.0
+        for subex in ex.args[2:end]
+            if isexpr(subex, :call) && subex.args[1] == :*
+                if length(subex.args) == 3
+                    # constant * variable
+                    @assert isa(subex.args[2], Number)
+                    @assert isa(subex.args[3], Symbol)
+                    push!(affine_coefficients, subex.args[2])
+                    push!(affine_variables, subex.args[3])
+                else
+                    # constant * variable * variable for quadratic
+                    @assert length(subex.args) == 4 "Multiplication with more than three terms not supported"
+                    @assert isa(subex.args[2], Number)
+                    @assert isa(subex.args[3], Symbol)
+                    @assert isa(subex.args[4], Symbol)
+                    if subex.args[3] == subex.args[4]
+                        push!(quadratic_coefficients, 2*subex.args[2])
+                    else
+                        push!(quadratic_coefficients, subex.args[2])
+                    end
+                    push!(quadratic_rowvariables, subex.args[3])
+                    push!(quadratic_colvariables, subex.args[4])
+                end
+            elseif isa(subex, Symbol)
+                push!(affine_coefficients, 1.0)
+                push!(affine_variables, subex)
+            else
+                @assert isa(subex, Number)
+                constant += subex
+            end
+        end
+        if length(quadratic_rowvariables) == 0
+            return ParsedScalarAffineFunction(affine_variables, affine_coefficients, constant)
+        else
+            return ParsedScalarQuadraticFunction(affine_variables, affine_coefficients, quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients, constant)
+        end
+    end
+end
+
+# see tests for examples
+function separatelabel(ex)
+    if isexpr(ex, :(:))
+        return ex.args[1], ex.args[2]
+    elseif isexpr(ex, :tuple)
+        ex = copy(ex)
+        @assert isexpr(ex.args[1], :(:))
+        label = ex.args[1].args[1]
+        ex.args[1] = ex.args[1].args[2]
+        return label, ex
+    elseif isexpr(ex, :call)
+        ex = copy(ex)
+        @assert isexpr(ex.args[2], :(:))
+        label = ex.args[2].args[1]
+        ex.args[2] = ex.args[2].args[2]
+        return label, ex
+    else
+        error("Unrecognized expression $ex")
+    end
+end
+
+function variabletoref(instance, s::Symbol)
+    return MOI.get(instance, MOI.VariableReference, String(s))
+end
+
+function variabletoref(instance, s::Vector{Symbol})
+    return MOI.get.(instance, MOI.VariableReference, String.(s))
+end
+
+variabletoref(instance, s) = s
+
+
+for typename in [:ParsedScalarAffineFunction,:ParsedVectorAffineFunction,
+                 :ParsedScalarQuadraticFunction,:ParsedVectorQuadraticFunction,
+                 :ParsedSingleVariable,:ParsedVectorOfVariables]
+    moiname = parse(replace(string(typename), "Parsed", "MOI."))
+    fields = fieldnames(eval(typename))
+    constructor = Expr(:call, moiname, [Expr(:call,:variabletoref,:instance,Expr(:.,:f,Base.Meta.quot(field))) for field in fields]...)
+    @eval parsedtoMOI(instance, f::$typename) = $constructor
+end
+
+function loadfromstring!(instance, s)
+    parsedlines = filter(ex -> ex != nothing,parse.(split(s,"\n")))
+
+    for line in parsedlines
+        label, ex = separatelabel(line)
+        if label == :variables
+            if isexpr(ex, :tuple)
+                for v in ex.args
+                    vref = MOI.addvariable!(instance)
+                    MOI.set!(instance, MOI.VariableName(), vref, String(v))
+                end
+            else
+                @assert isa(ex, Symbol)
+                vref = MOI.addvariable!(instance)
+                MOI.set!(instance, MOI.VariableName(), vref, String(ex))
+            end
+        elseif label == :maxobjective
+            f = parsefunction(ex)
+            MOI.set!(instance, MOI.ObjectiveFunction(), parsedtoMOI(instance, f))
+            MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
+        elseif label == :minobjective
+            f = parsefunction(ex)
+            MOI.set!(instance, MOI.ObjectiveFunction(), parsedtoMOI(instance, f))
+            MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
+        else
+            # constraint
+            @assert isexpr(ex, :call)
+            f = parsefunction(ex.args[2])
+            if ex.args[1] == :in
+                # Could be safer here
+                set = eval(MOI, ex.args[3])
+            elseif ex.args[1] == :<=
+                set = MOI.LessThan(ex.args[3])
+            elseif ex.args[1] == :>=
+                set = MOI.GreaterThan(ex.args[3])
+            elseif ex.args[1] == :(==)
+                set = MOI.EqualTo(ex.args[3])
+            else
+                error("Unrecognized expression $ex")
+            end
+            cref = MOI.addconstraint!(instance, parsedtoMOI(instance, f), set)
+            MOI.set!(instance, MOI.ConstraintName(), cref, String(label))
+        end
+    end
+end
+

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1,0 +1,127 @@
+
+structeq(a::T, b::T) where {T} = all(f->getfield(a, f) == getfield(b, f), fieldnames(T))
+
+@testset "parsefunction" begin
+    @test structeq(MOIU.parsefunction(:x), MOIU.ParsedSingleVariable(:x))
+    @test structeq(MOIU.parsefunction(:([x,y,z])), MOIU.ParsedVectorOfVariables([:x,:y,:z]))
+    @test structeq(MOIU.parsefunction(:(x + y + 2.0)), MOIU.ParsedScalarAffineFunction([:x,:y],[1.0,1.0],2.0))
+    @test structeq(MOIU.parsefunction(:(x + -3y + 2.0)), MOIU.ParsedScalarAffineFunction([:x,:y],[1.0,-3.0],2.0))
+    @test structeq(MOIU.parsefunction(:(2*x*y + y + 1.0)), MOIU.ParsedScalarQuadraticFunction([:y],[1.0],[:x],[:y],[2.0],1.0))
+    @test_throws AssertionError MOIU.parsefunction(:(x - y))
+
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0])), MOIU.ParsedVectorAffineFunction([1,2,2],[:x,:x,:y],[1.0,2.0,1.0],[0.0,5.0]))
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0, 1*x*x])), MOIU.ParsedVectorQuadraticFunction([1,2,2],[:x,:x,:y],[1.0,2.0,1.0],[3],[:x],[:x],[2.0],[0.0,5.0,0.0]))
+
+end
+
+@testset "separatelabel" begin
+    @test MOIU.separatelabel(:(variables: x)) == (:variables, :x)
+    @test MOIU.separatelabel(:(variables: x, y)) == (:variables, :((x,y)))
+    @test MOIU.separatelabel(:(minobjective: x + y)) == (:minobjective, :(x+y))
+    @test MOIU.separatelabel(:(con1: 2x <= 1)) == (:con1, :(2x <= 1))
+    @test MOIU.separatelabel(:(con1: [x,y] in S)) == (:con1, :([x,y] in S))
+end
+
+@MOIU.instance GeneralInstance (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+
+@testset "loadfromstring" begin
+    @testset "one variable" begin
+        s = """
+        variables: x
+        bound: x >= 1.0
+        """
+        instance = GeneralInstance{Float64}()
+        x = MOI.addvariable!(instance)
+        MOI.set!(instance, MOI.VariableName(), x, "x")
+        bound = MOI.addconstraint!(instance, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
+        MOI.set!(instance, MOI.ConstraintName(), bound, "bound")
+
+        instance2 = GeneralInstance{Float64}()
+        MOIU.loadfromstring!(instance2, s)
+        MOIU.test_instances_equal(instance, instance2, ["x"], ["bound"])
+    end
+
+    @testset "linear constraints" begin
+        s = """
+        variables: x, y
+        linear1: x + y >= 1.0
+        linear2: x + y <= 1.0
+        linear3: x + y == 1.0
+        """
+        instance = GeneralInstance{Float64}()
+        x = MOI.addvariable!(instance)
+        y = MOI.addvariable!(instance)
+        MOI.set!(instance, MOI.VariableName(), x, "x")
+        MOI.set!(instance, MOI.VariableName(), y, "y")
+        linear1 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y],[1.0,1.0],0.0), MOI.GreaterThan(1.0))
+        linear2 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y],[1.0,1.0],0.0), MOI.LessThan(1.0))
+        linear3 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([x,y],[1.0,1.0],0.0), MOI.EqualTo(1.0))
+        MOI.set!(instance, MOI.ConstraintName(), linear1, "linear1")
+        MOI.set!(instance, MOI.ConstraintName(), linear2, "linear2")
+        MOI.set!(instance, MOI.ConstraintName(), linear3, "linear3")
+
+        instance2 = GeneralInstance{Float64}()
+        MOIU.loadfromstring!(instance2, s)
+        MOIU.test_instances_equal(instance, instance2, ["x", "y"], ["linear1", "linear2", "linear3"])
+    end
+
+    @testset "minimization: linear objective" begin
+        s = """
+        variables: x, y
+        minobjective: x + -2y + 1.0
+        """
+        instance = GeneralInstance{Float64}()
+        x = MOI.addvariable!(instance)
+        y = MOI.addvariable!(instance)
+        MOI.set!(instance, MOI.VariableName(), x, "x")
+        MOI.set!(instance, MOI.VariableName(), y, "y")
+        MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y],[1.0,-2.0],1.0))
+        MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
+
+        instance2 = GeneralInstance{Float64}()
+        MOIU.loadfromstring!(instance2, s)
+        MOIU.test_instances_equal(instance, instance2, ["x", "y"], String[])
+    end
+
+    @testset "maximization: linear objective" begin
+        s = """
+        variables: x, y
+        maxobjective: x + -2y + 1.0
+        """
+        instance = GeneralInstance{Float64}()
+        x = MOI.addvariable!(instance)
+        y = MOI.addvariable!(instance)
+        MOI.set!(instance, MOI.VariableName(), x, "x")
+        MOI.set!(instance, MOI.VariableName(), y, "y")
+        MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y],[1.0,-2.0],1.0))
+        MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
+
+        instance2 = GeneralInstance{Float64}()
+        MOIU.loadfromstring!(instance2, s)
+        MOIU.test_instances_equal(instance, instance2, ["x", "y"], String[])
+    end
+
+    @testset "SOC constraints" begin
+        s = """
+        variables: x, y, z
+        varsoc: [x,y,z] in SecondOrderCone(2)
+        affsoc: [2x,y+1,-1*z] in SecondOrderCone(2)
+        """
+        instance = GeneralInstance{Float64}()
+        x = MOI.addvariable!(instance)
+        y = MOI.addvariable!(instance)
+        z = MOI.addvariable!(instance)
+        MOI.set!(instance, MOI.VariableName(), x, "x")
+        MOI.set!(instance, MOI.VariableName(), y, "y")
+        MOI.set!(instance, MOI.VariableName(), z, "z")
+        varsoc = MOI.addconstraint!(instance, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(2))
+        affsoc = MOI.addconstraint!(instance, MOI.VectorAffineFunction([1,2,3],[x,y,z],[2.0,1.0,-1.0],[0.0,1.0,0.0]), MOI.SecondOrderCone(2))
+        MOI.set!(instance, MOI.ConstraintName(), varsoc, "varsoc")
+        MOI.set!(instance, MOI.ConstraintName(), affsoc, "affsoc")
+
+        instance2 = GeneralInstance{Float64}()
+        MOIU.loadfromstring!(instance2, s)
+        MOIU.test_instances_equal(instance, instance2, ["x", "y", "z"], ["varsoc", "affsoc"])
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,3 +9,4 @@ const MOI = MathOptInterface
 include("functions.jl")
 include("sets.jl")
 include("instance.jl")
+include("parser.jl")


### PR DESCRIPTION
Meant to be used in tests:
```julia
s = """
variables: x, y, z
minobjective: 2x + 3y
con1: x + y <= 1
con2: [x,2*y*z] in SecondOrderCone(2)
"""
instance = Instance{Float64}()
MOIU.loadfromstring!(instance, s)
```
now you can:
- test if `instance` matches an instance generated by JuMP
- give `instance` to a solver and see if it returns a certain answer

This will make the MOI tests *much* more compact and will let me test JuMP's model generation separately from the connection to solvers.

Some more comments on the format are in the code.

Quadratic and vector expressions are already supported and tested. Currently blocked by  ~https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/21~ ~#25~.

@odow