### PR TITLE
[RFC] allocateload!

### DIFF
--- a/src/copy.jl
+++ b/src/copy.jl
@@ -100,12 +100,12 @@ end
 
 # To support `MOI.copy!` using this 2-pass mechanism, implement the allocate-load interface defined below and do:
 # MOI.copy!(dest::InstanceType, src::MOI.AbstractInstance) = MOIU.allocateload!(dest, src)
-# In the implementation of the allocate-load interface, it can be assumed that the different function will the called in the following order:
+# In the implementation of the allocate-load interface, it can be assumed that the different functions will the called in the following order:
 # 1) `allocatevariables!`
 # 2) `allocate!` and `allocateconstraint!`
 # 3) `loadvariables!` and `allocateconstraint!`
 # 4) `load!` and `loadconstraint!`
-# The interface is not meant to be used to create new constraints with `allocateconstraint!` followed by `loadconstrained!` after a solve, it is only meant for being used in this order to implement `MOI.copy!`.
+# The interface is not meant to be used to create new constraints with `allocateconstraint!` followed by `loadconstraint!` after a solve, it is only meant for being used in this order to implement `MOI.copy!`.
 
 """
     allocatevariables!(instance::MOI.AbstractInstance, nvars::Integer)


### PR DESCRIPTION
It turns out that the three wrappers (SDOI, SCS, ECOS) not supporting `MOI.addconstraints!`, ... and hence not able to use `MOIU.defaultcopy!` can implement a 2-pass version of `MOIU.defaultcopy!`.
During the first pass is called `allocate` : the wrappers, collects the relevant information about the problem so that on the second pass called `load`, the constraints can be loaded directly to the solver (in case of SDOI) or written directly into the matrix of constraints (in case of SCS and ECOS).
The three wrappers now implements `MOI.copy!` by using `MOI.allocateload!` : the relevant PRs are https://github.com/JuliaOpt/SemidefiniteOptInterface.jl/pull/8, https://github.com/JuliaOpt/MathOptInterfaceECOS.jl/pull/2 and https://github.com/JuliaOpt/MathOptInterfaceSCS.jl/pull/5.
The wrappers simply need to implement the 6 functions of the allocate-load API and do
```julia
MOI.copy!(dest::WrapperType, src::MOI.AbstractInstance) = MOIU.allocateload!(dest, src)
```
and `MOI.copy!` will work for `WrapperType`.
The allocate-load API only make sense in the order in which each function is called. The wrapper is free to do whatever it wants in each function. For instance, the main importance of `loadvariable!` is that it is called between the `allocateconstraint!` and `loadconstraint!` so it can be used for tasks that need to be done between the two.

The API is not meant to be used to create new constraints with `allocateconstraint!` followed by `loadconstrained!` after a solve, it is only meant for `copy!`.