### PR TITLE
Replace linear1test copy paste with MOIT tests

### DIFF
--- a/test/instance.jl
+++ b/test/instance.jl
@@ -3,7 +3,7 @@ MOIU.@instance LPInstance () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, 
 MOIU.@instance(Instance,
                (), # <- example of giving no set
                (EqualTo, GreaterThan, LessThan, Interval),
-               (Reals, Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle),
+               (Reals, Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, RootDetConeTriangle, LogDetConeTriangle),
                (PowerCone, DualPowerCone),
                (SingleVariable,), # <- example of giving only one set
                (ScalarAffineFunction, ScalarQuadraticFunction),
@@ -29,156 +29,16 @@ end
     MOIT.copytest(Instance{Float64}(), Instance{Float64}())
 end
 
-# Taken from MOI/test/contlinear.jl
-@testset "Basic solve, query, resolve" begin
-    # simple 2 variable, 1 constraint problem
-    # min -x
-    # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
-    #       x, y >= 0   (x, y ∈ Nonnegatives)
+const solver = () -> Instance{Float64}()
+# Only config.query is true as MOI.optimize! is not implemented
+const config = MOIT.TestConfig(0., 0., false, true, false, false)
 
-    instance = Instance{Float64}()
+@testset "Continuous Linear tests" begin
+    MOIT.contlineartest(solver, config)
+end
 
-    v = MOI.addvariables!(instance, 2)
-    @test MOI.get(instance, MOI.NumberOfVariables()) == 2
-    @test MOI.canget(instance, MOI.ListOfVariableIndices())
-    vrs = MOI.get(instance, MOI.ListOfVariableIndices())
-    @test vrs == v || vrs == reverse(v)
-
-    cf = MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0)
-    c = MOI.addconstraint!(instance, cf, MOI.LessThan(1.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
-
-    vc1 = MOI.addconstraint!(instance, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
-    vc2 = MOI.addconstraint!(instance, v[2], MOI.GreaterThan(0.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
-
-    objf = MOI.ScalarAffineFunction(v, [-1.0,0.0], 0.0)
-    MOI.set!(instance, MOI.ObjectiveFunction(), objf)
-    MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
-
-    @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MinSense
-
-    @test MOI.canget(instance, MOI.ObjectiveFunction())
-    @test objf ≈ MOI.get(instance, MOI.ObjectiveFunction())
-
-    @test MOI.canget(instance, MOI.ConstraintFunction(), c)
-    @test cf ≈ MOI.get(instance, MOI.ConstraintFunction(), c)
-
-    @test MOI.canget(instance, MOI.ConstraintSet(), c)
-    s = MOI.get(instance, MOI.ConstraintSet(), c)
-    @test s == MOI.LessThan(1.0)
-
-    @test MOI.canget(instance, MOI.ConstraintSet(), vc1)
-    s = MOI.get(instance, MOI.ConstraintSet(), vc1)
-    @test s == MOI.GreaterThan(0.0)
-
-    @test MOI.canget(instance, MOI.ConstraintSet(), vc2)
-    s = MOI.get(instance, MOI.ConstraintSet(), vc2)
-    @test s == MOI.GreaterThan(0.0)
-
-    # change objective to Max +x
-
-    objf = MOI.ScalarAffineFunction(v, [1.0,0.0], 0.0)
-    MOI.set!(instance, MOI.ObjectiveFunction(), objf)
-    MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
-
-    @test MOI.canget(instance, MOI.ObjectiveFunction())
-    @test objf ≈ MOI.get(instance, MOI.ObjectiveFunction())
-
-    @test MOI.get(instance, MOI.ObjectiveSense()) == MOI.MaxSense
-
-    # add new variable to get :
-    # max x + 2z
-    # s.t. x + y + z <= 1
-    # x,y,z >= 0
-
-    z = MOI.addvariable!(instance)
-    push!(v, z)
-    @test v[3] == z
-    @test cf.variables == v
-    @test MOI.get(instance, MOI.ConstraintFunction(), c).variables == [v[1], v[2]]
-    @test MOI.get(instance, MOI.ObjectiveFunction()).variables == [v[1], v[2]]
-
-    vc3 = MOI.addconstraint!(instance, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
-
-    @test MOI.canmodifyconstraint(instance, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
-    MOI.modifyconstraint!(instance, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
-
-    @test MOI.canmodifyobjective(instance, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
-    MOI.modifyobjective!(instance, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
-
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
-
-    # setting lb of x to -1 to get :
-    # max x + 2z
-    # s.t. x + y + z <= 1
-    # x >= -1
-    # y,z >= 0
-
-    MOI.modifyconstraint!(instance, vc1, MOI.GreaterThan(-1.0))
-
-    # put lb of x back to 0 and fix z to zero to get :
-    # max x + 2z
-    # s.t. x + y + z <= 1
-    # x, y >= 0, z = 0
-
-    MOI.modifyconstraint!(instance, vc1, MOI.GreaterThan(0.0))
-    @test MOI.isvalid(instance, vc3)
-    MOI.delete!(instance, vc3)
-    @test !MOI.isvalid(instance, vc3)
-    vc3 = MOI.addconstraint!(instance, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
-
-    # modify affine linear constraint set to be == 2 to get :
-    # max x + 2z
-    # s.t. x + y + z == 2
-    # x,y >= 0, z = 0
-
-    @test MOI.isvalid(instance, c)
-    MOI.delete!(instance, c)
-    @test !MOI.isvalid(instance, c)
-    cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
-    c = MOI.addconstraint!(instance, cf, MOI.EqualTo(2.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
-
-    # modify objective function to x + 2y to get :
-    # max x + 2y
-    # s.t. x + y + z == 2
-    # x,y >= 0, z = 0
-
-    objf = MOI.ScalarAffineFunction(v, [1.0,2.0,0.0], 0.0)
-    MOI.set!(instance, MOI.ObjectiveFunction(), objf)
-    MOI.set!(instance, MOI.ObjectiveSense(), MOI.MaxSense)
-
-    # add constraint x - y >= 0 to get :
-    # max x+2y
-    # s.t. x + y + z == 2
-    # x - y >= 0
-    # x,y >= 0, z = 0
-
-    cf2 = MOI.ScalarAffineFunction(v, [1.0, -1.0, 0.0], 0.0)
-    c2 = MOI.addconstraint!(instance, cf2, MOI.GreaterThan(0.0))
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-    @test MOI.get(instance, MOI.ConstraintFunction(), c2) ≈ cf2
-
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
-    MOI.delete!(instance, v[1])
-    @test MOI.get(instance, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
-
-    f = MOI.get(instance, MOI.ConstraintFunction(), c2)
-    @test f.variables == [v[2], z]
-    @test f.coefficients == [-1.0, 0.0]
-
-    @test MOI.canget(instance, MOI.ListOfVariableIndices())
-    vrs = MOI.get(instance, MOI.ListOfVariableIndices())
-    @test vrs == [v[2], z] || vrs == [z, v[2]]
-    @test MOI.get(instance, MOI.ObjectiveFunction()) ≈ MOI.ScalarAffineFunction([v[2], z], [2.0, 0.0], 0.0)
-
+@testset "Continuous Conic tests" begin
+    MOIT.contconictest(solver, config)
 end
 
 @testset "Quadratic functions" begin


### PR DESCRIPTION
By setting `config.solve` to `false`, the MOIU instance can pass MOIT tests