### PR TITLE
Supertype of InstanceManager is AbstractSolverInstance

### DIFF
--- a/src/instancemanager.jl
+++ b/src/instancemanager.jl
@@ -21,7 +21,7 @@ An `InstanceManger` has two modes of operation (`InstanceManagerMode`):
 - `Manual`: The only methods that change the state of the `InstanceManager` are [`resetsolver!`](@ref), [`dropsolver!`](@ref), and [`attachsolver!`](@ref). Attempting to perform an operation in the incorrect state results in an error.
 - `Automatic`: The `InstanceManager` changes its state when necessary. For example, `optimize!` will automatically call `attachsolver!` (a solver must have been previously set). Attempting to add a constraint or perform a modification not supported by the solver results in a drop to `EmptySolver` mode.
 """
-mutable struct InstanceManager <: MOI.AbstractSolverInstance
+mutable struct InstanceManager <: MOI.AbstractInstance
     instance::MOI.AbstractStandaloneInstance
     solver::Union{Void,MOI.AbstractSolverInstance}
     state::InstanceManagerState
@@ -34,6 +34,13 @@ mutable struct InstanceManager <: MOI.AbstractSolverInstance
 end
 
 InstanceManager(instance::MOI.AbstractStandaloneInstance, mode::InstanceManagerMode) = InstanceManager(instance, nothing, NoSolver, mode, IndexMap(), IndexMap())
+
+"""
+    InstanceManager(instance::AbstractStandaloneInstance, solver::AbstractSolverInstance)
+
+Creates an `InstanceManager` in `Automatic` mode, with the solver `solver`. The instance manager returned behaves like an `AbstractSolverInstance` as long as no `InstanceManager`-specific functions (e.g. `dropsolver!`) are called on it.
+"""
+InstanceManager(instance::MOI.AbstractStandaloneInstance, solver::MOI.AbstractSolverInstance) = InstanceManager(instance, solver, EmptySolver, Automatic, IndexMap(), IndexMap())
 
 ## Methods for managing the state of InstanceManager.
 

--- a/src/instancemanager.jl
+++ b/src/instancemanager.jl
@@ -21,7 +21,7 @@ An `InstanceManger` has two modes of operation (`InstanceManagerMode`):
 - `Manual`: The only methods that change the state of the `InstanceManager` are [`resetsolver!`](@ref), [`dropsolver!`](@ref), and [`attachsolver!`](@ref). Attempting to perform an operation in the incorrect state results in an error.
 - `Automatic`: The `InstanceManager` changes its state when necessary. For example, `optimize!` will automatically call `attachsolver!` (a solver must have been previously set). Attempting to add a constraint or perform a modification not supported by the solver results in a drop to `EmptySolver` mode.
 """
-mutable struct InstanceManager
+mutable struct InstanceManager <: MOI.AbstractSolverInstance
     instance::MOI.AbstractStandaloneInstance
     solver::Union{Void,MOI.AbstractSolverInstance}
     state::InstanceManagerState

--- a/test/instance.jl
+++ b/test/instance.jl
@@ -10,9 +10,6 @@ MOIU.@instance(Instance,
                (VectorOfVariables,),
                (VectorAffineFunction, VectorQuadraticFunction))
 
-using MathOptInterfaceTests
-const MOIT = MathOptInterfaceTests
-
 @testset "Name test" begin
     MOIT.nametest(Instance{Float64}())
 end

--- a/test/instancemanager.jl
+++ b/test/instancemanager.jl
@@ -1,5 +1,5 @@
 
-@MOIU.instance InstanceForManager (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.instance InstanceForManager (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, RootDetConeTriangle, LogDetConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
 
 @testset "InstanceManager Manual mode" begin
     m = MOIU.InstanceManager(InstanceForManager{Float64}(), MOIU.Manual)
@@ -143,4 +143,15 @@ end
 
     # TODO: test modifyconstraint! with a change that forces the solver to be dropped
 
+end
+
+@testset "InstanceManager constructor with solver" begin
+    function solver()
+        s = MOIU.MockSolverInstance(InstanceForMock{Float64}())
+        m = MOIU.InstanceManager(InstanceForManager{Float64}(), s)
+        @test MOIU.mode(m) == MOIU.Automatic
+        m
+    end
+    config = MOIT.TestConfig(solve=false)
+    MOIT.contconictest(solver, config)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,13 @@
-using MathOptInterfaceUtilities
-const MOIU = MathOptInterfaceUtilities
-
 using Base.Test
 
 using MathOptInterface
 const MOI = MathOptInterface
+
+using MathOptInterfaceTests
+const MOIT = MathOptInterfaceTests
+
+using MathOptInterfaceUtilities
+const MOIU = MathOptInterfaceUtilities
 
 include("functions.jl")
 include("sets.jl")


### PR DESCRIPTION
AbstractSolverInstance and not AbstractStandaloneInstance since it can `optimize!`. We could also just do AbstractInstance if you prefer.
It is critical that `InstanceManager` is an AbstractInstance for https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/34.
I am currently trying to update ECOS so that to remove the internal copy of the model. In the tests, I give an ECOSInstance wrapped in an InstanceManager to the MOIT tests. MOIT test expect and AbstractInstance so if InstanceManager is not an AbstractInstance it won't work. A simple example is that tests assume
https://github.com/JuliaOpt/MathOptInterface.jl/blob/d10d7a967221645400559c99836f9b71330f8e70/src/constraints.jl#L31-L33
works. Later it could also be `setobjective!`. One other issue is that no layer can be put on top of InstanceManager if it is not an AbstractInstance (see https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/56).