### PR TITLE
Use AttachedSolver state when both instance and solver are empty

### DIFF
--- a/src/instancemanager.jl
+++ b/src/instancemanager.jl
@@ -130,6 +130,9 @@ function MOI.empty!(m::InstanceManager)
     if m.state == AttachedSolver
         MOI.empty!(m.solver)
     end
+    if m.state == EmptySolver && m.mode == Automatic
+        m.state = AttachedSolver
+    end
     m.instancetosolvermap = IndexMap()
     m.solvertoinstancemap = IndexMap()
 end

--- a/src/instancemanager.jl
+++ b/src/instancemanager.jl
@@ -40,7 +40,7 @@ InstanceManager(instance::MOI.AbstractStandaloneInstance, mode::InstanceManagerM
 
 Creates an `InstanceManager` in `Automatic` mode, with the solver `solver`. The instance manager returned behaves like an `AbstractSolverInstance` as long as no `InstanceManager`-specific functions (e.g. `dropsolver!`) are called on it.
 """
-InstanceManager(instance::MOI.AbstractStandaloneInstance, solver::MOI.AbstractSolverInstance) = InstanceManager(instance, solver, EmptySolver, Automatic, IndexMap(), IndexMap())
+InstanceManager(instance::MOI.AbstractStandaloneInstance, solver::MOI.AbstractSolverInstance) = InstanceManager(instance, solver, AttachedSolver, Automatic, IndexMap(), IndexMap())
 
 ## Methods for managing the state of InstanceManager.
 

--- a/test/instancemanager.jl
+++ b/test/instancemanager.jl
@@ -143,6 +143,8 @@ end
 
     # TODO: test modifyconstraint! with a change that forces the solver to be dropped
 
+    MOI.empty!(m)
+    @test MOIU.state(m) == MOIU.AttachedSolver
 end
 
 @testset "InstanceManager constructor with solver" begin

--- a/test/instancemanager.jl
+++ b/test/instancemanager.jl
@@ -149,7 +149,7 @@ end
     s = MOIU.MockSolverInstance(InstanceForMock{Float64}())
     m = MOIU.InstanceManager(InstanceForManager{Float64}(), s)
     @test MOI.isempty(m)
-    @test MOIU.state(m) == MOIU.EmptySolver
+    @test MOIU.state(m) == MOIU.AttachedSolver
     @test MOIU.mode(m) == MOIU.Automatic
 end
 


### PR DESCRIPTION
When both are empty, AttachedSolver is preferable to EmptySolver in Automatic mode as it gives the opportunity to the solver to stay attached if it can (it will be detached anyway if it cannot keep up)